### PR TITLE
使用户能够在配置文件中自定义上传保存路径

### DIFF
--- a/config/settings.dev.yml
+++ b/config/settings.dev.yml
@@ -10,6 +10,7 @@ settings:
     port: "8002"
     readtimeout: 1
     writertimeout: 2
+    uploda: ./upload
   database:
     dbtype: mysql
     host: 127.0.0.1

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -10,6 +10,7 @@ settings:
     port: 8002
     readtimeout: 1
     writertimeout: 2
+    upload: ./upload
   database:
     dbtype: mysql
     host: 127.0.0.1

--- a/router/router.go
+++ b/router/router.go
@@ -5,6 +5,7 @@ import (
 	"ferry/router/dashboard"
 	"ferry/router/process"
 	systemRouter "ferry/router/system"
+	"github.com/spf13/viper"
 
 	ginSwagger "github.com/swaggo/gin-swagger"
 	"github.com/swaggo/gin-swagger/swaggerFiles"
@@ -21,6 +22,9 @@ func InitSysRouter(r *gin.Engine, authMiddleware *jwtauth.GinJWTMiddleware) *gin
 	// 静态文件
 	sysStaticFileRouter(g)
 
+	// 上传文件
+	sysUploadFileRouter(g)
+
 	// swagger；注意：生产环境可以注释掉
 	sysSwaggerRouter(g)
 
@@ -35,6 +39,10 @@ func InitSysRouter(r *gin.Engine, authMiddleware *jwtauth.GinJWTMiddleware) *gin
 
 func sysStaticFileRouter(r *gin.RouterGroup) {
 	r.Static("/static", "./static")
+}
+
+func sysUploadFileRouter(r *gin.RouterGroup) {
+	r.Static("/upload", viper.GetString("settings.application.upload"))
 }
 
 func sysSwaggerRouter(r *gin.RouterGroup) {

--- a/router/router.go
+++ b/router/router.go
@@ -5,8 +5,7 @@ import (
 	"ferry/router/dashboard"
 	"ferry/router/process"
 	systemRouter "ferry/router/system"
-	"github.com/spf13/viper"
-
+	"ferry/tools/config"
 	ginSwagger "github.com/swaggo/gin-swagger"
 	"github.com/swaggo/gin-swagger/swaggerFiles"
 
@@ -42,7 +41,7 @@ func sysStaticFileRouter(r *gin.RouterGroup) {
 }
 
 func sysUploadFileRouter(r *gin.RouterGroup) {
-	r.Static("/upload", viper.GetString("settings.application.upload"))
+	r.Static("/upload", config.ApplicationConfig.Upload)
 }
 
 func sysSwaggerRouter(r *gin.RouterGroup) {

--- a/tools/config/application.go
+++ b/tools/config/application.go
@@ -13,6 +13,7 @@ type Application struct {
 	DemoMsg       string
 	Domain        string
 	IsHttps       bool
+	Upload        string
 }
 
 func InitApplication(cfg *viper.Viper) *Application {
@@ -27,6 +28,7 @@ func InitApplication(cfg *viper.Viper) *Application {
 		DemoMsg:       cfg.GetString("demoMsg"),
 		Domain:        cfg.GetString("domain"),
 		IsHttps:       cfg.GetBool("ishttps"),
+		Upload:        uploadDefault(cfg),
 	}
 }
 
@@ -38,6 +40,13 @@ func portDefault(cfg *viper.Viper) string {
 	} else {
 		return cfg.GetString("port")
 	}
+}
+
+func uploadDefault(cfg *viper.Viper) string {
+	if cfg.GetString("upload") == "" {
+		return "./upload"
+	}
+	return cfg.GetString("upload")
 }
 
 func isHttpsDefault(cfg *viper.Viper) bool {


### PR DESCRIPTION
更新说明
1. 添加一个Upload静态文件处理handler, 路径为: /upload
2. 增加settings.application.upload配置
3. 修改file upload逻辑

目的
1. 使项目静态文件和上传文件分离，让其更易于维护。

注：
- 使用postman测试，单文件，多文件，base64上传， 通过(能够通过浏览器访问到上传文件)
- 需要修改配置说明文档，修改upload访问location

以前
```
location /static/uploadfile {
       proxy_pass http://localhost:8002;
}
```

修改后
```
location /upload {
      proxy_pass http://localhost:8002;
}
```