### PR TITLE
use DialTLS instead of StartTLS on ldap.Conn

### DIFF
--- a/pkg/ldap/connection.go
+++ b/pkg/ldap/connection.go
@@ -22,25 +22,18 @@ var conn *ldap.Conn
 func ldapConnection() (err error) {
 	var ldapConn = fmt.Sprintf("%v:%v", viper.GetString("settings.ldap.host"), viper.GetString("settings.ldap.port"))
 
-	conn, err = ldap.Dial(
-		"tcp",
-		ldapConn,
-	)
+	if viper.GetBool("settings.ldap.tls") {
+		tlsconf := &tls.Config{
+			InsecureSkipVerify: true,
+		}
+		conn, err = ldap.DialTLS("tcp", ldapConn, tlsconf)
+	} else {
+		conn, err = ldap.Dial("tcp", ldapConn)
+	}
 	if err != nil {
 		err = errors.New(fmt.Sprintf("无法连接到ldap服务器，%v", err))
 		logger.Error(err)
 		return
-	}
-
-	if viper.GetBool("settings.ldap.tls") {
-		err = conn.StartTLS(&tls.Config{
-			InsecureSkipVerify: true,
-		})
-		if err != nil {
-			err = errors.New(fmt.Sprintf("升级到加密方式失败，%v", err))
-			logger.Error(err)
-			return
-		}
 	}
 
 	//设置超时时间


### PR DESCRIPTION
以下代码在 OpenLDAP 服务端情况下跑不通，需要改成直接使用 `DialTLS`

```go
	conn, err := ldap.Dial("tcp", "127.0.0.1:636")
	if err != nil {
		log.Fatal(err)
	}
	err = conn.StartTLS(&tls.Config{
		InsecureSkipVerify: true,
	})
	if err != nil {
		log.Fatal(err)
	}

```

开启 TLS 的服务端这段会报错

```
unable to read LDAP response packet: unexpected EOF
```

看起来是因为 `ldap.Conn.Dial` 方法里已经启用过 `Start()` 

https://github.com/go-ldap/ldap/blob/ca1c5e50f5d619519efb7df8bc5f0d78af5920d8/v3/conn.go#L178

同样的方法在 `DialTLS` 里也调用了。