### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/robfig/cron/v3 v3.0.0
 	github.com/satori/go.uuid v1.2.0
-	github.com/shirou/gopsutil v2.20.3+incompatible
+	github.com/shirou/gopsutil v3.20.10+incompatible
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/viper v1.6.2
 	github.com/swaggo/gin-swagger v1.2.0


### PR DESCRIPTION
```
go run main.go server -c=config/settings.dev.yml

# github.com/shirou/gopsutil/disk
vendor/github.com/shirou/gopsutil/disk/disk_darwin.go:67:51: cannot use stat.Mntfromname[:] (type []byte) as type []int8 in argument to common.IntToString
vendor/github.com/shirou/gopsutil/disk/disk_darwin.go:68:49: cannot use stat.Mntonname[:] (type []byte) as type []int8 in argument to common.IntToString
vendor/github.com/shirou/gopsutil/disk/disk_darwin.go:69:50: cannot use stat.Fstypename[:] (type []byte) as type []int8 in argument to common.IntToString
vendor/github.com/shirou/gopsutil/disk/disk_darwin.go:85:43: cannot use stat.Fstypename[:] (type []byte) as type []int8 in argument to common.IntToString
```


update gopsutil v3.20.10+incompatible