### PR TITLE
bugfix: fix auth check return error msg

### DIFF
--- a/pkg/jwtauth/jwtauth.go
+++ b/pkg/jwtauth/jwtauth.go
@@ -608,7 +608,7 @@ func (mw *GinJWTMiddleware) jwtFromHeader(c *gin.Context, key string) (string, e
 
 	parts := strings.SplitN(authHeader, " ", 2)
 	if !(len(parts) == 2 && parts[0] == mw.TokenHeadName) {
-		return "", ErrInvalidAuthHeader
+		return "-", ErrInvalidAuthHeader
 	}
 
 	return parts[1], nil


### PR DESCRIPTION
when your browse can not use cookie and you send a request with wrong token format in header，
in old code will return msg with cookie token is empty
in new code will return msg with auth header is invalid
it just is a small bug, and almost impossible to show up