### PR TITLE
修复拒绝工单时 is_denied字段没有置为1问题

### DIFF
--- a/pkg/service/handle.go
+++ b/pkg/service/handle.go
@@ -195,6 +195,7 @@ func (h *Handle) circulation() (err error) {
 		Where("id = ?", h.workOrderId).
 		Updates(map[string]interface{}{
 			"state":          stateValue,
+			"is_denied":      h.flowProperties,
 			"related_person": h.updateValue["related_person"],
 		}).Error
 	if err != nil {


### PR DESCRIPTION
拒绝工单时，is_denied字段没有更新