### PR TITLE
Init sql miss is_verify_code in table sys_settings, fix auth problem.

### DIFF
--- a/handler/auth.go
+++ b/handler/auth.go
@@ -99,7 +99,7 @@ func Authenticator(c *gin.Context) (interface{}, error) {
 		return nil, errors.New("获取是否需要验证码校验失败")
 	}
 
-	if isVerifyCode.(bool) {
+	if isVerifyCode != nil && isVerifyCode.(bool) {
 		// 校验验证码
 		if !store.Verify(loginVal.UUID, loginVal.Code, true) {
 			loginLog.Status = "1"


### PR DESCRIPTION
Error trace when use ldap:

2022/01/12 10:01:03 http: panic serving 192.168.18.3:13193: interface conversion: interface {} is nil, not bool
goroutine 100 [running]:
net/http.(*conn).serve.func1()
        /usr/local/Cellar/go/1.17.2/libexec/src/net/http/server.go:1801 +0xb9
panic({0x1e101e0, 0xc0005ffbc0})
        /usr/local/Cellar/go/1.17.2/libexec/src/runtime/panic.go:1047 +0x266
ferry/middleware.CustomError.func1()
        /Users/ipet/Documents/devops/ferry/middleware/customerror.go:44 +0x47f
panic({0x1e101e0, 0xc0005ffbc0})
        /usr/local/Cellar/go/1.17.2/libexec/src/runtime/panic.go:1038 +0x215
**ferry/handler.Authenticator(0xc00065d700)
        /Users/ipet/Documents/devops/ferry/handler/auth.go:102 +0x10d7**
ferry/pkg/jwtauth.(*GinJWTMiddleware).LoginHandler(0xc00022a000, 0xc000bd6840)
        /Users/ipet/Documents/devops/ferry/pkg/jwtauth/jwtauth.go:445 +0x51
github.com/gin-gonic/gin.(*Context).Next(...)
        /Users/ipet/go/pkg/mod/github.com/gin-gonic/gin@v1.7.0/context.go:165