### PR TITLE
Update build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -206,7 +206,7 @@ function install_front {
     config_front
     echo_green "\n>>> $(gettext '开始安装前端依赖...')"
     cnpm_base_dir=$(dirname $(dirname $(which npm)))
-    npm install -g cnpm --registry=https://registry.npm.taobao.org --prefix ${cnpm_base_dir}
+    npm install -g cnpm --registry=https://registry.npmmirror.com --prefix ${cnpm_base_dir}
     cd ferry_web && cnpm install && npm run build:prod && cp -r web ../build/template && cp -r web/static/* ../build/static/
 
 }


### PR DESCRIPTION
build.sh脚本里用的淘宝老的 http://registry.npm.taobao.org 域名已停止服务，需要切换到https://registry.npmmirror.com